### PR TITLE
capturejs should pass the --ignore-ssl-errors parameter to phantomjs 

### DIFF
--- a/lib/capturejs.js
+++ b/lib/capturejs.js
@@ -89,9 +89,9 @@ module.exports.capture = function (option, callback) {
     };
 
     // Setup arguments for Phantom.js
-    ['cookies-file'].forEach(function (key) {
+    ['cookies-file', 'ignore-ssl-errors'].forEach(function (key) {
         if (option[key]) {
-            args.push(['--', key, '=', option['cookies-file']].join(''));
+            args.push(['--', key, '=', option[key]].join(''));
         }
     });
     args.push(phantomHandler);

--- a/opts.json
+++ b/opts.json
@@ -42,6 +42,13 @@
         "required": false
     },
     {
+        "short": "I",
+        "long": "ignore-ssl-errors",
+        "description": "Ignores SSL errors (expired/self-signed certificate errors)",
+        "value": true,
+        "required": false
+    },
+    {
         "short": "o",
         "long": "output",
         "description": "Output Image File",


### PR DESCRIPTION
I have added the option to accept the `--ignore-ssl-errors` from `capturejs` to `phantomjs`.

I think it might be useful for many of us.
