### PR TITLE
Adding random port and slight delay.

### DIFF
--- a/lib/capturejs.js
+++ b/lib/capturejs.js
@@ -4,11 +4,17 @@
 
 var phantom = require('phantom');
 
+// Pick a random int between two ranges.
+function get_random_port(min, max) {
+    return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
 module.exports.capture = function (option, callback) {
     callback = callback || function () { return undefined; };
 
     var args = [],
-        phantomHandler;
+        phantomHandler,
+        port = get_random_port(40000, 60000);
 
     // Handler for Phantom.js
     phantomHandler = function (ph) {
@@ -79,10 +85,15 @@ module.exports.capture = function (option, callback) {
                     if (rect !== null) {
                         page.set('clipRect', rect);
                     }
-                    page.render(option.output, function () {
-                        ph.exit();
-                        process.nextTick(callback);
-                    });
+                    // Set a timeout to give the page a chance to render
+                    setTimeout(function () {
+                        page.render(option.output, function () {
+                            ph.exit();
+                            process.nextTick(callback);
+                        });
+                    }, 250);
+
+
                 });
             });
         });
@@ -96,6 +107,22 @@ module.exports.capture = function (option, callback) {
     });
     args.push(phantomHandler);
 
-    // Execute Phantom.js
+
+    // Set the handler in case we grab an in-use port.
+    process.on('uncaughtException', function (err) {
+        if (err.errno === 'EADDRINUSE') {
+            port = get_random_port(40000, 60000);
+            args.unshift({'port': port});
+            phantom.create.apply(phantom, args);
+        } else {
+            console.log(err);
+            process.exit(1);
+        }
+    });
+
+    // Pick a random port for phantom to use on start up
+
+    args.unshift({'port': port});
     phantom.create.apply(phantom, args);
+
 };


### PR DESCRIPTION
1. Phantomjs now starts up on a random port, between 40,000 and 60,000. Allows chapturejs to run in parallel.
2. render() is now called with a 250ms timeout, to give javascript a chance to render before we capture.

It might be nice to make the timeout configurable via the command line, and/or pass in the port instead of randomly picking one. 
