### PR TITLE
Unsubscribe from 'uncaughtException' when page rendering is finished

### DIFF
--- a/lib/capturejs.js
+++ b/lib/capturejs.js
@@ -12,7 +12,8 @@ module.exports.capture = function (option, callback) {
 
     var args = [],
         phantomHandler,
-        port = getRandomPort(40000, 60000);
+        createPhantomInstance,
+        onUncaughtException;
 
     // Handler for Phantom.js
     phantomHandler = function (ph) {
@@ -100,6 +101,7 @@ module.exports.capture = function (option, callback) {
                     setTimeout(function () {
                         page.render(option.output, function () {
                             ph.exit();
+                            process.removeListener("uncaughtException", onUncaughtException);
                             process.nextTick(callback);
                         });
                     }, option.renderdelay || 250);
@@ -108,6 +110,22 @@ module.exports.capture = function (option, callback) {
                 });
             });
         });
+    };
+
+    createPhantomInstance = function(args) {
+        // Pick a random port for phantom to use on start up
+        var port = getRandomPort(40000, 60000);
+        args.unshift({"port": port});
+        phantom.create.apply(phantom, args);
+    };
+
+    onUncaughtException = function(err) {
+        if (err.errno === "EADDRINUSE") {
+            createPhantomInstance(args);
+        } else {
+            console.log(err);
+            process.exit(1);
+        }
     };
 
     // Setup arguments for Phantom.js
@@ -120,21 +138,9 @@ module.exports.capture = function (option, callback) {
 
 
     // Set the handler in case we grab an in-use port.
-    process.on("uncaughtException", function (err) {
-        if (err.errno === "EADDRINUSE") {
-            port = getRandomPort(40000, 60000);
-            args.unshift({"port": port});
-            phantom.create.apply(phantom, args);
-        } else {
-            console.log(err);
-            process.exit(1);
-        }
-    });
+    process.on("uncaughtException", onUncaughtException);
 
-    // Pick a random port for phantom to use on start up
-
-    args.unshift({"port": port});
-    phantom.create.apply(phantom, args);
+    createPhantomInstance(args);
 
 };
 // vim: set fenc=utf-8 ts=4 sts=4 sw=4 :


### PR DESCRIPTION
Hello, I was using `capturejs` to continuously capture screenshots and caught a very handy warning from node:

> (node) warning: possible EventEmitter memory leak detected. 11 listeners added. Use emitter.setMaxListeners() to increase limit.

It turned out that utility `uncaughtException` subscription was not detached after screen capture and leaked. This pull request removes the said listener after phantom instance is terminated.