### PR TITLE
Add: waitcapturedelay option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Options:
   -c, --cookies-file <value>       Cookies file
   -T, --timeout <value>            HTTP Timeout (ms)
   -R, --renderdelay <value>        Render delay (ms)
+  -W, --waitcapturedelay <value>   Capture delay (ms)
   -z, --zoomfactor <value>         Zoom Factor (default is 1.0, i.e. 100% zoom)
 
   -v, --version                    Show version number and exit

--- a/lib/capturejs.js
+++ b/lib/capturejs.js
@@ -83,6 +83,8 @@ module.exports.capture = function (option, callback) {
                         injectScript = "function(){" + injectScript + "}";
                     }
                     page.evaluate(injectScript, capureFunction);
+                } else if (option.waitcapturedelay) {
+                    setTimeout(capureFunction, +option.waitcapturedelay);
                 } else {
                     capureFunction();
                 }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -23,6 +23,7 @@ cli.start = function (argv) {
             "cookies-file": path,
             timeout: Number,
             renderdelay: Number,
+            waitcapturedelay: Number,
             zoomfactor: Number,
             help: Boolean,
             version: Boolean
@@ -43,7 +44,8 @@ cli.start = function (argv) {
             R: "--renderdelay",
             z: "--zoomfactor",
             h: "--help",
-            v: "--version"
+            v: "--version",
+            w: "--waitcapturedelay"
         },
         errors = [],
         parsed;


### PR DESCRIPTION
Additional delay is necessary when we capture SPA pages with async loading and when calculate rect we don't know it's size.